### PR TITLE
refactor(http): standardize server response format

### DIFF
--- a/.cursor/docs/project-milestone.md
+++ b/.cursor/docs/project-milestone.md
@@ -14,7 +14,9 @@ Old monograph link: https://monogr.ph/664d42567e3a71c23dfea211 -- I think this l
 1. Dynamically configuring healthcheck targets and/or incident alerting
 2. Uptime Kuma API compatibility for sending uptime checks (refer to this specific file + commit https://github.com/teknologi-umum/bot/blob/7382c332521018a51ae33f26bb068be65dadd0df/src/uptime.js) (found something here https://www.postman.com/gabrielfnlima/uptime-kuma-api-collection/collection/vadwal6/uptime-kuma-rest-api)
 3. TLS certificate expiration notice for pull-based (...probably?)
-4. ...more?## Things to do
+4. ...more?
+
+## Things to do
 
 We need to check if these already implemented and already works.
 
@@ -22,7 +24,7 @@ We need to check if these already implemented and already works.
 - [ ] Able to configure sites, dynamically (through web UI) or statically (through config files) -- I think the last time we implemented this was through config files, since the UI would be a read only. But we'll see if we can change this to be dynamically.
 - [x] Able to poll to target sites (meaning we make a HTTP request [or any other protocol] to that endpoint)
 - [x] Able to save healthcheck data to some storage backends. (see https://github.com/teknologi-umum/semyi/issues/26, https://github.com/teknologi-umum/semyi/issues/23)
-- [ ] Able to retrieve healthcheck result remotely (similar to how push-mechanism works in app monitoring/observability)
+- [x] Able to retrieve healthcheck result remotely (similar to how push-mechanism works in app monitoring/observability)
 - [ ] HTTP API endpoint for list healthcheck results (for web UI)
 
 ### Alerting

--- a/.cursor/rules/teknologi-umum--semyi.mdc
+++ b/.cursor/rules/teknologi-umum--semyi.mdc
@@ -7,4 +7,14 @@ One rule that you need to adhere: Whenever you are unsure about a specific part,
 
 Refer to [project-milestone.md](mdc:.cursor/docs/project-milestone.md) for guarding on things to be done.
 
-Whenever possible, always put an in-code documentation of your decision that answers "Why a certain things are done this way?"
+Whenever possible, always put an in-code documentation of your decision that answers "Why a certain things are done this way?".
+
+If you need to create a commit, follow Angular's Conventional Commit: @https://www.conventionalcommits.org/en/v1.0.0-beta.4/, which has the style of:
+```
+<type>[optional scope]: <description>
+
+[optional body]
+
+[optional footer]
+```
+With `type` being one of `fix`, `feat`, `chore`, `docs`, `style`, `refactor`, `perf`, and `test`. For commit body, instead of putting `\n` on the body message, use multiple `-m` flags instead. Example: `git commit -m "docs(cursor): Enhance Cursor rules to respect conventional commit" -m "Previously, the commit message does not have a specific rule, and for each developer, they might have different settings on what kind of commit message they should do." -m "Through this change, every commit made by Cursor should follow Angular's Conventional Commit"`.

--- a/backend/http_response.go
+++ b/backend/http_response.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"time"
+)
+
+// HttpCommonError represents a standardized error response
+type HttpCommonError struct {
+	Error string `json:"error"`
+}
+
+// HttpCommonSuccess represents a standardized success response
+type HttpCommonSuccess struct {
+	Message string `json:"message"`
+}
+
+// HttpCommonData represents a standardized data response
+type HttpCommonData struct {
+	Data interface{} `json:"data"`
+}
+
+// StaticSnapshotResponse represents the response for /api/static endpoint
+type StaticSnapshotResponse struct {
+	Metadata   Monitor             `json:"metadata"`
+	Historical []MonitorHistorical `json:"historical"`
+}
+
+// MonitorHistoricalResponse represents a single monitor historical data point
+type MonitorHistoricalResponse struct {
+	MonitorID string        `json:"monitor_id"`
+	Status    MonitorStatus `json:"status"`
+	Latency   int64         `json:"latency"`
+	Timestamp time.Time     `json:"timestamp"`
+}
+
+// SSEEvent represents a Server-Sent Event
+type SSEEvent struct {
+	Event string      `json:"event"`
+	Data  interface{} `json:"data"`
+}


### PR DESCRIPTION
This PR introduces standardized response structs for HTTP endpoints to make the API responses more type-safe and self-documenting.

## Changes
- Added `HttpCommonError` for error responses
- Added `HttpCommonSuccess` for success responses
- Added `StaticSnapshotResponse` for `/api/static` endpoint
- Added `MonitorHistoricalResponse` for historical data points
- Added `SSEEvent` for Server-Sent Events

## Benefits
- Type-safe responses
- Self-documenting API
- Consistent response format across endpoints
- Better maintainability
- Easier to understand API contract

## Testing
- [ ] Verify all endpoints return the correct response format
- [ ] Test error cases return proper error responses
- [ ] Verify SSE endpoints still work as expected


> [!WARNING]
> I vibe-coded this.