### PR TITLE
feat(alerter): implement multiple alert providers

### DIFF
--- a/.cursor/docs/project-milestone.md
+++ b/.cursor/docs/project-milestone.md
@@ -1,4 +1,3 @@
-
 ## Must Have Project Capabilities
 
 1. Make healthcheck requests to target (similar to pull-based app monitoring/observability)
@@ -14,18 +13,16 @@ Old monograph link: https://monogr.ph/664d42567e3a71c23dfea211 -- I think this l
 1. Dynamically configuring healthcheck targets and/or incident alerting
 2. Uptime Kuma API compatibility for sending uptime checks (refer to this specific file + commit https://github.com/teknologi-umum/bot/blob/7382c332521018a51ae33f26bb068be65dadd0df/src/uptime.js) (found something here https://www.postman.com/gabrielfnlima/uptime-kuma-api-collection/collection/vadwal6/uptime-kuma-rest-api)
 3. TLS certificate expiration notice for pull-based (...probably?)
-4. ...more?
-
-## Things to do
+4. ...more?## Things to do
 
 We need to check if these already implemented and already works.
 
 ### Healthcheck
-- [ ] Able to configure sites, dynamically (through web UI) or statically (through config files) -- I think the last time we implemented this was through config files, since the UI would be a read only. But we'll see if we can change this to be dynamically.
+- [x] Able to configure sites, ~~dynamically (through web UI)~~ or statically (through config files) -- I think the last time we implemented this was through config files, since the UI would be a read only. But we'll see if we can change this to be dynamically.
 - [x] Able to poll to target sites (meaning we make a HTTP request [or any other protocol] to that endpoint)
 - [x] Able to save healthcheck data to some storage backends. (see https://github.com/teknologi-umum/semyi/issues/26, https://github.com/teknologi-umum/semyi/issues/23)
-- [x] Able to retrieve healthcheck result remotely (similar to how push-mechanism works in app monitoring/observability)
-- [ ] HTTP API endpoint for list healthcheck results (for web UI)
+- [x] Able to retrieve healthcheck result remotely (similar to how push-mechanism works in app monitoring/observability) #45 
+- [x] HTTP API endpoint for list healthcheck results (for web UI) -- Validated here https://github.com/teknologi-umum/semyi/pull/51
 
 ### Alerting
 - [ ] Able to send an alert to some platform (see https://github.com/teknologi-umum/semyi/issues/7, https://github.com/teknologi-umum/semyi/issues/8, https://github.com/teknologi-umum/semyi/issues/27)

--- a/.cursor/docs/project-monograph.md
+++ b/.cursor/docs/project-monograph.md
@@ -1,0 +1,40 @@
+## Problem Statement
+
+Teknologi Umum community uses Uptime Kuma at the moment, it works, but sometimes it doesn't. The alerting and many things to monitor works great, but these are a few things that are missing from the perfect status page in our case:
+
+* You can't put more description about what this service is about
+* You can't see the incident history
+* Everything is either "up" or "down", you can't put a "degraded performance" or "under maintenance" status.
+* Users can't see longer uptime status other than the last 48 minutes (since the interval is 1 minute).
+* There are no public chart for service latency.
+
+Basically, the "perfect status page" in our case is something close to Atlassian Statuspage or Betterstack Status or current Uptime Kuma with some improvements. 
+
+A few good status pages that's publicly exists out there:
+
+* https://status.digitalocean.com/ (uses Atlassian Statuspage)
+* https://www.intercomstatus.com/ (uses Atlassian Statuspage)
+* https://slack-status.com/ (I like how they provide RSS feed, and how simple the UI is. You can see the historical status in their detail page https://slack-status.com/calendar)
+* https://status.railway.app/ (uses Instatus, very good UI)
+* https://status.cronitor.io/ (I like the latency graph)
+* https://meta.hyperping.app/
+
+## Solution Sketch
+
+We're trying to continue teknologi-umum/semyi and abandon (probably will delete this repository) teknologi-umum/ohana. We'll still be using regular Go as backend and SPA frontend server. The container should be collapsed into one, rather than creating two separate Docker containers for backend and frontend.
+
+Features that should be implemented:
+
+* Configurable intervals, with the lowest being 30 seconds. Lower than 30 seconds is... kinda pointless for a status page.
+* Unlimited number of things to be monitored.
+* Should implement similar Uptime Kuma API, so teknologi-umum/roselite wouldn't be a waste.
+* Should support these kinds of monitors:
+    * HTTP monitoring
+    * TLS/SSL monitoring -- certificate expiry notification, certificate headers checking (issuer, subject, common name, etc)
+    * Ping/ICMP monitoring
+* Should support these providers for alerts:
+    * Webhook/HTTP
+    * Email
+    * Telegram (this is priority)
+    * Discord (least concern)
+* Should be able to submit incident via HTTP API and through config file.

--- a/.cursor/rules/teknologi-umum--semyi.mdc
+++ b/.cursor/rules/teknologi-umum--semyi.mdc
@@ -5,7 +5,7 @@ alwaysApply: true
 ---
 One rule that you need to adhere: Whenever you are unsure about a specific part, do ask of the thing you are confused in. Never give out an answer, even if you are forced to do so.
 
-Refer to [project-milestone.md](mdc:.cursor/docs/project-milestone.md) for guarding on things to be done.
+Refer to [project-milestone.md](mdc:.cursor/docs/project-milestone.md) and [project-monograph.md](mdc:.cursor/docs/project-monograph.md) for guarding on things to be done.
 
 Whenever possible, always put an in-code documentation of your decision that answers "Why a certain things are done this way?".
 

--- a/backend/alerter.go
+++ b/backend/alerter.go
@@ -1,11 +1,7 @@
 package main
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
-	"fmt"
-	"net/http"
 	"time"
 )
 
@@ -20,68 +16,4 @@ type AlertMessage struct {
 	MonitorID   string
 	MonitorName string
 	Latency     int64
-}
-
-type TelegramProvider struct {
-	url    string
-	chatID string
-}
-
-type TelegramProviderConfig struct {
-	Url    string
-	ChatID string
-}
-
-func NewTelegramAlertProvider(config TelegramProviderConfig) *TelegramProvider {
-	return &TelegramProvider{
-		url: config.Url,
-	}
-}
-
-func (t TelegramProvider) Send(ctx context.Context, msg AlertMessage) error {
-	if t.url == "" || t.chatID == "" {
-		return fmt.Errorf("can't make a telegram alert request: some config is not set")
-	}
-
-	// Perhaps we can use a template file instead.
-	title := "🔴 Down"
-	if msg.Success {
-		title = "✅ Up"
-	}
-	text := fmt.Sprintf(title+`
-
-	**MonitorID:** %s
-	**MonitorName:** %s
-	**StatusCode:** %d
-	**Latency:** %d
-	**Timestamp:** %s`,
-		msg.MonitorID,
-		msg.MonitorName,
-		msg.StatusCode,
-		msg.Latency,
-		msg.Timestamp.Format(time.RFC3339),
-	)
-	payload := map[string]any{
-		"chat_id":    t.chatID,
-		"text":       text,
-		"parse_mode": "Markdown",
-	}
-	payloadByte, _ := json.Marshal(payload)
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, t.url, bytes.NewReader(payloadByte))
-	if err != nil {
-		return fmt.Errorf("failed to send telegram alert: %w", err)
-	}
-	defer req.Body.Close()
-
-	req.Header.Set("Content-Type", "application/json")
-
-	client := http.Client{Timeout: time.Second * 3}
-
-	_, err = client.Do(req)
-	if err != nil {
-		return fmt.Errorf("failed to make request: %w", err)
-	}
-
-	return nil
 }

--- a/backend/alerter_discord.go
+++ b/backend/alerter_discord.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+type DiscordProvider struct {
+	webhookURL string
+	httpClient *http.Client
+}
+
+type DiscordProviderConfig struct {
+	WebhookURL string
+	HttpClient *http.Client
+}
+
+func NewDiscordAlertProvider(config DiscordProviderConfig) *DiscordProvider {
+	if config.HttpClient == nil {
+		config.HttpClient = &http.Client{Timeout: time.Minute}
+	}
+	return &DiscordProvider{
+		webhookURL: config.WebhookURL,
+		httpClient: config.HttpClient,
+	}
+}
+
+// Ensure DiscordProvider implements Alerter interface
+var _ Alerter = (*DiscordProvider)(nil)
+
+func (d *DiscordProvider) Send(ctx context.Context, msg AlertMessage) error {
+	if d.webhookURL == "" {
+		return fmt.Errorf("can't make a discord alert request: webhook URL is not set")
+	}
+
+	// Create a Discord embed message
+	title := "🔴 Service Down"
+	if msg.Success {
+		title = "✅ Service Up"
+	}
+
+	// Discord embed color (red for down, green for up)
+	color := 0xFF0000 // Red
+	if msg.Success {
+		color = 0x00FF00 // Green
+	}
+
+	// Format the message as a Discord embed
+	embed := map[string]interface{}{
+		"title": title,
+		"color": color,
+		"fields": []map[string]string{
+			{
+				"name":   "Monitor ID",
+				"value":  msg.MonitorID,
+				"inline": "true",
+			},
+			{
+				"name":   "Monitor Name",
+				"value":  msg.MonitorName,
+				"inline": "true",
+			},
+			{
+				"name":   "Status Code",
+				"value":  fmt.Sprintf("%d", msg.StatusCode),
+				"inline": "true",
+			},
+			{
+				"name":   "Latency",
+				"value":  fmt.Sprintf("%d ms", msg.Latency),
+				"inline": "true",
+			},
+			{
+				"name":   "Timestamp",
+				"value":  msg.Timestamp.Format(time.RFC3339),
+				"inline": "true",
+			},
+		},
+	}
+
+	payload := map[string]interface{}{
+		"embeds": []map[string]interface{}{embed},
+	}
+
+	payloadBytes, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("failed to marshal discord payload: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, d.webhookURL, bytes.NewReader(payloadBytes))
+	if err != nil {
+		return fmt.Errorf("failed to create discord request: %w", err)
+	}
+	defer req.Body.Close()
+
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := d.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to make discord request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNoContent && resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("discord webhook returned non-200 status code: %d", resp.StatusCode)
+	}
+
+	return nil
+}

--- a/backend/alerter_http.go
+++ b/backend/alerter_http.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+type HTTPProvider struct {
+	webhookURL string
+	httpClient *http.Client
+}
+
+type HTTPProviderConfig struct {
+	WebhookURL string
+	HttpClient *http.Client
+}
+
+func NewHTTPAlertProvider(config HTTPProviderConfig) *HTTPProvider {
+	if config.HttpClient == nil {
+		config.HttpClient = &http.Client{Timeout: time.Second * 3}
+	}
+
+	return &HTTPProvider{
+		webhookURL: config.WebhookURL,
+		httpClient: config.HttpClient,
+	}
+}
+
+// Ensure HTTPProvider implements Alerter interface
+var _ Alerter = (*HTTPProvider)(nil)
+
+func (h *HTTPProvider) Send(ctx context.Context, msg AlertMessage) error {
+	if h.webhookURL == "" {
+		return fmt.Errorf("can't make a HTTP webhook request: webhook URL is not set")
+	}
+
+	// Format the message as a JSON payload
+	payload := map[string]interface{}{
+		"success":      msg.Success,
+		"monitor_id":   msg.MonitorID,
+		"monitor_name": msg.MonitorName,
+		"status_code":  msg.StatusCode,
+		"latency":      msg.Latency,
+		"timestamp":    msg.Timestamp.Format(time.RFC3339),
+	}
+
+	payloadBytes, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("failed to marshal HTTP webhook payload: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, h.webhookURL, bytes.NewReader(payloadBytes))
+	if err != nil {
+		return fmt.Errorf("failed to create HTTP webhook request: %w", err)
+	}
+	defer req.Body.Close()
+
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := h.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to make HTTP webhook request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
+		return fmt.Errorf("HTTP webhook returned non-200 status code: %d", resp.StatusCode)
+	}
+
+	return nil
+}

--- a/backend/alerter_slack.go
+++ b/backend/alerter_slack.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+type SlackProvider struct {
+	webhookURL string
+	httpClient *http.Client
+}
+
+type SlackProviderConfig struct {
+	WebhookURL string
+	HttpClient *http.Client
+}
+
+func NewSlackAlertProvider(config SlackProviderConfig) *SlackProvider {
+	if config.HttpClient == nil {
+		config.HttpClient = &http.Client{Timeout: time.Second * 3}
+	}
+
+	return &SlackProvider{
+		webhookURL: config.WebhookURL,
+		httpClient: config.HttpClient,
+	}
+}
+
+// Ensure SlackProvider implements Alerter interface
+var _ Alerter = (*SlackProvider)(nil)
+
+func (s *SlackProvider) Send(ctx context.Context, msg AlertMessage) error {
+	if s.webhookURL == "" {
+		return fmt.Errorf("can't make a Slack webhook request: webhook URL is not set")
+	}
+
+	// Create a Slack message using Block Kit format
+	title := "🔴 Service Down"
+	if msg.Success {
+		title = "✅ Service Up"
+	}
+
+	// Create blocks for the Slack message
+	blocks := []map[string]interface{}{
+		{
+			"type": "header",
+			"text": map[string]string{
+				"type": "plain_text",
+				"text": title,
+			},
+		},
+		{
+			"type": "section",
+			"fields": []map[string]string{
+				{
+					"type": "mrkdwn",
+					"text": fmt.Sprintf("*Monitor ID*\n%s", msg.MonitorID),
+				},
+				{
+					"type": "mrkdwn",
+					"text": fmt.Sprintf("*Monitor Name*\n%s", msg.MonitorName),
+				},
+				{
+					"type": "mrkdwn",
+					"text": fmt.Sprintf("*Status Code*\n%d", msg.StatusCode),
+				},
+				{
+					"type": "mrkdwn",
+					"text": fmt.Sprintf("*Latency*\n%d ms", msg.Latency),
+				},
+			},
+		},
+		{
+			"type": "context",
+			"elements": []map[string]string{
+				{
+					"type": "mrkdwn",
+					"text": fmt.Sprintf("Timestamp: %s", msg.Timestamp.Format(time.RFC3339)),
+				},
+			},
+		},
+	}
+
+	// Create the payload
+	payload := map[string]interface{}{
+		"text":   fmt.Sprintf("%s: %s (%s)", title, msg.MonitorName, msg.MonitorID),
+		"blocks": blocks,
+	}
+
+	payloadBytes, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("failed to marshal Slack payload: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, s.webhookURL, bytes.NewReader(payloadBytes))
+	if err != nil {
+		return fmt.Errorf("failed to create Slack webhook request: %w", err)
+	}
+	defer req.Body.Close()
+
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to make Slack webhook request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
+		return fmt.Errorf("Slack webhook returned non-200 status code: %d", resp.StatusCode)
+	}
+
+	return nil
+}

--- a/backend/alerter_telegram.go
+++ b/backend/alerter_telegram.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+type TelegramProvider struct {
+	url        string
+	chatID     string
+	httpClient *http.Client
+}
+
+type TelegramProviderConfig struct {
+	Url        string
+	ChatID     string
+	HttpClient *http.Client
+}
+
+func NewTelegramAlertProvider(config TelegramProviderConfig) *TelegramProvider {
+	if config.HttpClient == nil {
+		config.HttpClient = &http.Client{Timeout: time.Minute}
+	}
+
+	return &TelegramProvider{
+		url:        config.Url,
+		chatID:     config.ChatID,
+		httpClient: config.HttpClient,
+	}
+}
+
+// Ensure TelegramProvider implements Alerter interface
+var _ Alerter = (*TelegramProvider)(nil)
+
+func (t *TelegramProvider) Send(ctx context.Context, msg AlertMessage) error {
+	if t.url == "" || t.chatID == "" {
+		return fmt.Errorf("can't make a telegram alert request: some config is not set")
+	}
+
+	// Perhaps we can use a template file instead.
+	title := "🔴 Down"
+	if msg.Success {
+		title = "✅ Up"
+	}
+	text := fmt.Sprintf(title+`
+
+	**MonitorID:** %s
+	**MonitorName:** %s
+	**StatusCode:** %d
+	**Latency:** %d
+	**Timestamp:** %s`,
+		msg.MonitorID,
+		msg.MonitorName,
+		msg.StatusCode,
+		msg.Latency,
+		msg.Timestamp.Format(time.RFC3339),
+	)
+	payload := map[string]any{
+		"chat_id":    t.chatID,
+		"text":       text,
+		"parse_mode": "Markdown",
+	}
+	payloadByte, _ := json.Marshal(payload)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, t.url, bytes.NewReader(payloadByte))
+	if err != nil {
+		return fmt.Errorf("failed to send telegram alert: %w", err)
+	}
+	defer req.Body.Close()
+
+	req.Header.Set("Content-Type", "application/json")
+
+	_, err = t.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to make request: %w", err)
+	}
+
+	return nil
+}

--- a/backend/config.go
+++ b/backend/config.go
@@ -41,6 +41,8 @@ const (
 	AlertProviderTypeUnspecified AlertProviderType = ""
 	AlertProviderTypeTelegram    AlertProviderType = "telegram"
 	AlertProviderTypeDiscord     AlertProviderType = "discord"
+	AlertProviderTypeHTTP        AlertProviderType = "http"
+	AlertProviderTypeSlack       AlertProviderType = "slack"
 )
 
 type Monitor struct {

--- a/backend/main.go
+++ b/backend/main.go
@@ -86,6 +86,21 @@ func main() {
 		log.Warn().Msg("TELEGRAM_URL is not set")
 	}
 
+	discordWebhookURL, ok := os.LookupEnv("DISCORD_WEBHOOK_URL")
+	if !ok {
+		log.Warn().Msg("DISCORD_WEBHOOK_URL is not set")
+	}
+
+	httpWebhookURL, ok := os.LookupEnv("HTTP_WEBHOOK_URL")
+	if !ok {
+		log.Warn().Msg("HTTP_WEBHOOK_URL is not set")
+	}
+
+	slackWebhookURL, ok := os.LookupEnv("SLACK_WEBHOOK_URL")
+	if !ok {
+		log.Warn().Msg("SLACK_WEBHOOK_URL is not set")
+	}
+
 	if os.Getenv("ENV") == "" {
 		err := os.Setenv("ENV", "development")
 		if err != nil {
@@ -156,10 +171,18 @@ func main() {
 			Url:    telegramUrl,
 			ChatID: telegramChatID,
 		}),
-		historicalWriter:     monitorHistoricalWriter,
-		historicalReader:     monitorHistoricalReader,
-		discordAlertProvider: nil,
-		centralBroker:        centralBroker,
+		discordAlertProvider: NewDiscordAlertProvider(DiscordProviderConfig{
+			WebhookURL: discordWebhookURL,
+		}),
+		httpAlertProvider: NewHTTPAlertProvider(HTTPProviderConfig{
+			WebhookURL: httpWebhookURL,
+		}),
+		slackAlertProvider: NewSlackAlertProvider(SlackProviderConfig{
+			WebhookURL: slackWebhookURL,
+		}),
+		historicalWriter: monitorHistoricalWriter,
+		historicalReader: monitorHistoricalReader,
+		centralBroker:    centralBroker,
 	}
 
 	// Create a new worker


### PR DESCRIPTION
# Alert Provider Implementation

This PR implements multiple alert providers to enhance the monitoring system's notification capabilities.

## Changes
- Add Discord webhook alert provider with rich message formatting
- Add HTTP webhook alert provider for generic webhook integration
- Add Slack webhook alert provider with Block Kit formatting
- Move Telegram provider to its own file for better code organization
- Update configuration and processor to handle all providers
- Add environment variables for webhook URLs

## Testing
To test these changes:
1. Set the appropriate webhook URLs in environment variables:
   - DISCORD_WEBHOOK_URL
   - HTTP_WEBHOOK_URL
   - SLACK_WEBHOOK_URL
2. Configure monitors with the desired alert provider:
   - alert_provider: "discord"
   - alert_provider: "http"
   - alert_provider: "slack"

## Notes
- Each provider implements rich message formatting where supported
- Providers will log warnings if webhook URLs are not configured
- Error handling is implemented for all webhook requests

Closes #7, #8, #27

> [!WARNING]
> I vibe code this
