### PR TITLE
feat(monitor): add pull-based monitoring

### DIFF
--- a/backend/config.go
+++ b/backend/config.go
@@ -81,6 +81,7 @@ type MonitorType string
 const (
 	MonitorTypeHTTP MonitorType = "http"
 	MonitorTypePing MonitorType = "ping"
+	MonitorTypePull MonitorType = "pull"
 )
 
 type AlertProviderType string
@@ -233,6 +234,10 @@ func (m Monitor) Validate() (bool, error) {
 	case MonitorTypePing:
 		if m.IcmpHostname == "" {
 			return false, fmt.Errorf("hostname is required")
+		}
+	case MonitorTypePull:
+		if m.Interval <= 0 {
+			return false, fmt.Errorf("interval must be greater than 0")
 		}
 	default:
 		return false, fmt.Errorf("invalid monitor type")

--- a/backend/monitor_historical_writer.go
+++ b/backend/monitor_historical_writer.go
@@ -9,13 +9,6 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-type MonitorStatus uint8
-
-const (
-	MonitorStatusSuccess MonitorStatus = iota
-	MonitorStatusFailure
-)
-
 type MonitorHistoricalWriter struct {
 	db *sql.DB
 }

--- a/backend/monitor_status.go
+++ b/backend/monitor_status.go
@@ -1,0 +1,28 @@
+package main
+
+type MonitorStatus uint8
+
+const (
+	MonitorStatusSuccess MonitorStatus = iota
+	MonitorStatusFailure
+	MonitorStatusDegradedPerformance
+	MonitorStatusUnderMaintenance
+	MonitorStatusLimitedAvailability
+)
+
+func (s MonitorStatus) String() string {
+	switch s {
+	case MonitorStatusSuccess:
+		return "Success"
+	case MonitorStatusFailure:
+		return "Failure"
+	case MonitorStatusDegradedPerformance:
+		return "Degraded Performance"
+	case MonitorStatusUnderMaintenance:
+		return "Under Maintenance"
+	case MonitorStatusLimitedAvailability:
+		return "Limited Availability"
+	default:
+		return "Unknown"
+	}
+}


### PR DESCRIPTION
# Pull-Based Monitoring Implementation

This PR adds support for pull-based monitoring, allowing the system to monitor services that push their health status.

## Changes
- Add  for pull-based monitoring
- Add new monitor statuses:
  - 
  - 
  - 
- Move  to a separate file for better organization
- Add pull-based healthcheck backfilling functionality
- Update broker message header format

## Configuration Example


## How It Works
1. The system periodically checks for new data from pull-based monitors
2. If no data is received within the configured interval, the service is marked as down
3. The system backfills historical data to maintain continuity
4. New status types allow for more granular monitoring

## Testing
1. Configure a pull-based monitor
2. Send health status updates via the push endpoint
3. Verify the system correctly tracks the service status
4. Test the backfilling functionality by stopping updates

Closes #45
