### PR TITLE
feat(frontend): Enhance status display with detailed status types

### DIFF
--- a/frontend/src/components/EndpointOverviewCard/index.tsx
+++ b/frontend/src/components/EndpointOverviewCard/index.tsx
@@ -16,9 +16,10 @@ export default function EndpointOverviewCard(props: EndpointOverviewCardProps) {
     props.staticSnapshot || [],
   );
   const uptimeRate = createMemo(() => {
-    const uptime = snapshot().filter((r) => r.status === 0).length;
     const total = snapshot().length;
-    return ((uptime / total) * 100).toFixed(1);
+    if (total === 0) return 0;
+    const upCount = snapshot().filter((s) => s.status === 0).length;
+    return Math.round((upCount / total) * 100);
   });
   const avgRespTime = createMemo(() => {
     const total = snapshot().reduce((acc, r) => acc + (r.latency ?? 0), 0);

--- a/frontend/src/components/Status/index.tsx
+++ b/frontend/src/components/Status/index.tsx
@@ -89,7 +89,13 @@ export default function Status(props: StatusProps) {
                   props.snapshots?.[i]?.status !== undefined
                     ? props.snapshots[i].status === 0
                       ? "var(--color-emerald)"
-                      : "var(--color-red)"
+                      : props.snapshots[i].status === 1
+                      ? "var(--color-red)"
+                      : props.snapshots[i].status === 2
+                      ? "var(--color-amber)"
+                      : props.snapshots[i].status === 3
+                      ? "var(--color-blue)"
+                      : "var(--color-purple)"
                     : "var(--color-lighter-gray)"
                 }
                 fill-opacity="1"

--- a/frontend/src/components/Status/index.tsx
+++ b/frontend/src/components/Status/index.tsx
@@ -90,12 +90,12 @@ export default function Status(props: StatusProps) {
                     ? props.snapshots[i].status === 0
                       ? "var(--color-emerald)"
                       : props.snapshots[i].status === 1
-                      ? "var(--color-red)"
-                      : props.snapshots[i].status === 2
-                      ? "var(--color-amber)"
-                      : props.snapshots[i].status === 3
-                      ? "var(--color-blue)"
-                      : "var(--color-purple)"
+                        ? "var(--color-red)"
+                        : props.snapshots[i].status === 2
+                          ? "var(--color-amber)"
+                          : props.snapshots[i].status === 3
+                            ? "var(--color-blue)"
+                            : "var(--color-purple)"
                     : "var(--color-lighter-gray)"
                 }
                 fill-opacity="1"

--- a/frontend/src/components/StatusTooltip/index.tsx
+++ b/frontend/src/components/StatusTooltip/index.tsx
@@ -49,7 +49,18 @@ export default function Tooltip(props: TooltipProps) {
             <></>
           )}
           <span class={styles["tooltip__response-time"]}>Duration: {props.snapshot?.latency}ms</span>
-          <span class={styles["tooltip__response-time"]}>Status: {props.snapshot?.status === 0 ? "UP" : "DOWN"}</span>
+          <span class={styles["tooltip__response-time"]}>
+            Status:{" "}
+            {props.snapshot?.status === 0
+              ? "UP"
+              : props.snapshot?.status === 1
+              ? "DOWN"
+              : props.snapshot?.status === 2
+              ? "DEGRADED"
+              : props.snapshot?.status === 3
+              ? "MAINTENANCE"
+              : "LIMITED"}
+          </span>
         </Match>
       </Switch>
     </div>

--- a/frontend/src/components/StatusTooltip/index.tsx
+++ b/frontend/src/components/StatusTooltip/index.tsx
@@ -54,12 +54,12 @@ export default function Tooltip(props: TooltipProps) {
             {props.snapshot?.status === 0
               ? "UP"
               : props.snapshot?.status === 1
-              ? "DOWN"
-              : props.snapshot?.status === 2
-              ? "DEGRADED"
-              : props.snapshot?.status === 3
-              ? "MAINTENANCE"
-              : "LIMITED"}
+                ? "DOWN"
+                : props.snapshot?.status === 2
+                  ? "DEGRADED"
+                  : props.snapshot?.status === 3
+                    ? "MAINTENANCE"
+                    : "LIMITED"}
           </span>
         </Match>
       </Switch>

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -1,0 +1,8 @@
+:root {
+  --color-emerald: #10b981;
+  --color-red: #ef4444;
+  --color-amber: #f59e0b;
+  --color-blue: #3b82f6;
+  --color-purple: #8b5cf6;
+  --color-lighter-gray: #f3f4f6;
+} 

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -5,4 +5,4 @@
   --color-blue: #3b82f6;
   --color-purple: #8b5cf6;
   --color-lighter-gray: #f3f4f6;
-} 
+}

--- a/frontend/src/types/Snapshot.ts
+++ b/frontend/src/types/Snapshot.ts
@@ -1,6 +1,6 @@
 export interface Snapshot {
   monitor_id: string;
-  status: number;
+  status: 0 | 1 | 2 | 3 | 4; // 0: Success, 1: Failure, 2: Degraded, 3: Under Maintenance, 4: Limited
   latency: number;
   timestamp: string;
 }


### PR DESCRIPTION
feat(frontend): Enhance status display with detailed status types

This PR introduces more detailed status types in the frontend to better represent different monitoring states.

Changes made:
- Added support for Degraded, Under Maintenance, and Limited Availability statuses
- Updated status colors to reflect different states (Success: Emerald, Failure: Red, Degraded: Amber, Maintenance: Blue, Limited: Purple)
- Improved status tooltip to show detailed status information
- Enhanced Snapshot type with specific status values (0-4)
- Fixed uptime rate calculation in EndpointOverviewCard to handle edge cases

Testing:
- [ ] Verify all status types are displayed correctly
- [ ] Check color coding for different statuses
- [ ] Test tooltip displays correct status information
- [ ] Verify uptime calculation works as expected
