### PR TITLE
fix: frontend null historical

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ COPY config.json /config.json
 RUN go build -ldflags="-X 'main.release=$(git describe --tags --always)'" -o semyi .
 
 FROM debian:bookworm
-ENV ENV=production
+ENV ENVIRONMENT=production
 ENV STATIC_PATH=/app/src/dist
 ENV CONFIG_PATH=/data/config.json
 ENV DB_PATH=/data/db.duckdb

--- a/README.md
+++ b/README.md
@@ -21,6 +21,11 @@ services:
     volumes:
       - "./config.json:/data/config.json"
       - "./db.duckdb:/data/db.duckdb"
+    healthcheck:
+      test: "curl http://localhost:5000/api/_healthz
+      retries: 3
+      interval: 15s
+      timeout: 10s
 ```
 
 ### Environment Variables

--- a/backend/http.go
+++ b/backend/http.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/getsentry/sentry-go"
+	sentryhttp "github.com/getsentry/sentry-go/http"
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
 	"github.com/rs/cors"
@@ -72,8 +73,10 @@ func NewServer(config ServerConfig) *http.Server {
 	})
 
 	api := chi.NewRouter()
+	api.Use(middleware.Heartbeat("/_healthz"))
 	api.Use(corsMiddleware.Handler)
 	api.Use(middleware.RequestID)
+	api.Use(sentryhttp.New(sentryhttp.Options{}).Handle)
 	api.Get("/api/overview", server.snapshotOverview)
 	api.Get("/api/by", server.snapshotBy)
 	api.Get("/api/static", server.staticSnapshot)

--- a/backend/main.go
+++ b/backend/main.go
@@ -115,6 +115,7 @@ func main() {
 	if err != nil {
 		log.Fatal().Err(err).Msg("failed to initialize sentry")
 	}
+	defer sentry.Flush(time.Second * 10)
 
 	httpClient := &http.Client{
 		Transport: httpclient.NewSentryRoundTripper(nil, nil),
@@ -169,7 +170,7 @@ func main() {
 	defer func(db *sql.DB) {
 		err := db.Close()
 		if err != nil {
-			log.Fatal().Err(err).Msg("failed to close database")
+			log.Warn().Err(err).Msg("failed to close database")
 		}
 	}(db)
 
@@ -283,7 +284,7 @@ func main() {
 	}()
 
 	// Start the server
-	log.Printf("Starting server on port %s", port)
+	log.Info().Msgf("Starting server on port %s", port)
 	if e := server.ListenAndServe(); e != nil && !errors.Is(e, http.ErrServerClosed) {
 		log.Fatal().Err(err).Msg("Failed to start server")
 	}

--- a/backend/monitor_processor.go
+++ b/backend/monitor_processor.go
@@ -85,7 +85,7 @@ func (m *Processor) ProcessResponse(ctx context.Context, response Response) {
 
 	go func() {
 		if m.telegramAlertProvider == nil && m.discordAlertProvider == nil && m.httpAlertProvider == nil && m.slackAlertProvider == nil {
-			log.Warn().Msg("no alert providers are set")
+			log.Warn().Msg("no alert providers are set, skipping alert")
 			return
 		}
 

--- a/frontend/src/pages/Overview/index.tsx
+++ b/frontend/src/pages/Overview/index.tsx
@@ -79,7 +79,7 @@ export default function OverviewPage() {
                 monitorId={snapshot.metadata.id}
                 name={snapshot.metadata.name}
                 url={snapshot.metadata.public_url ?? ""}
-                staticSnapshot={snapshot.historical.reverse().slice(0, 100)}
+                staticSnapshot={snapshot.historical?.reverse().slice(0, 100) ?? []}
                 snapshotStream$={snapshotStream$}
               />
             );


### PR DESCRIPTION
Historical entry on frontend is null if no data exists, causing a TypeError.

Also added Sentry HTTP middleware, since I forgot about it
