### PR TITLE
fix(backend): Use monitor.UniqueID instead of monitorId in historical reader calls

### DIFF
--- a/backend/http.go
+++ b/backend/http.go
@@ -385,7 +385,7 @@ func (s *Server) staticSnapshot(w http.ResponseWriter, r *http.Request) {
 		var monitorHistorical []MonitorHistorical
 		switch interval {
 		case "raw":
-			monitorHistorical, err = s.historicalReader.ReadRawHistorical(ctx, monitorId)
+			monitorHistorical, err = s.historicalReader.ReadRawHistorical(ctx, monitor.UniqueID)
 			if err != nil {
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusInternalServerError)
@@ -394,7 +394,7 @@ func (s *Server) staticSnapshot(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 		case "hourly":
-			monitorHistorical, err = s.historicalReader.ReadHourlyHistorical(ctx, monitorId)
+			monitorHistorical, err = s.historicalReader.ReadHourlyHistorical(ctx, monitor.UniqueID)
 			if err != nil {
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusInternalServerError)
@@ -403,7 +403,7 @@ func (s *Server) staticSnapshot(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 		case "daily":
-			monitorHistorical, err = s.historicalReader.ReadDailyHistorical(ctx, monitorId)
+			monitorHistorical, err = s.historicalReader.ReadDailyHistorical(ctx, monitor.UniqueID)
 			if err != nil {
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusInternalServerError)


### PR DESCRIPTION
fix(backend): Use monitor.UniqueID instead of monitorId in historical reader calls

This PR fixes the usage of monitor ID in historical reader calls by replacing `monitorId` with `monitor.UniqueID` in the `staticSnapshot` function.

Changes made:
- Replace all instances of `monitorId` with `monitor.UniqueID` in historical reader calls
- Ensure consistency in ID usage across the codebase
- Fix potential issues with ID mismatch in historical data retrieval

This change helps maintain consistency in how we reference monitor IDs throughout the codebase and prevents potential issues with ID mismatch when retrieving historical data.
